### PR TITLE
exception for emos

### DIFF
--- a/src/main/java/com/example/emos/wx/exception/EmosException.java
+++ b/src/main/java/com/example/emos/wx/exception/EmosException.java
@@ -1,0 +1,8 @@
+package com.example.emos.wx.exception;
+
+import lombok.Data;
+
+@Data
+public class EmosException extends RuntimeException{
+
+}


### PR DESCRIPTION
Create an emos exception to catch an error code and a message. Lombok is accepted to generate accessors and mutators implicitly 