### PR TITLE
override getHeader to prevent XSS attack

### DIFF
--- a/src/main/java/com/example/emos/wx/config/xss/XssHttpServletRequestWrapper.java
+++ b/src/main/java/com/example/emos/wx/config/xss/XssHttpServletRequestWrapper.java
@@ -65,4 +65,14 @@ public class XssHttpServletRequestWrapper extends HttpServletRequestWrapper {
 
         return map;
     }
+
+    @Override
+    public String getHeader(String name) {
+        String value = super.getHeader(name);
+        if (!StrUtil.hasEmpty(value)) {
+            value = HtmlUtil.filter(value);
+        }
+        
+        return value;
+    }
 }


### PR DESCRIPTION
Override getHeader to filter the value to prevent the XSS attack since **getHeader will request from the header**

