### PR TITLE
Intermediary for OAuth2Filter & TokenAspect

### DIFF
--- a/src/main/java/com/example/emos/wx/config/shiro/ThreadLocalToken.java
+++ b/src/main/java/com/example/emos/wx/config/shiro/ThreadLocalToken.java
@@ -1,0 +1,8 @@
+package com.example.emos.wx.config.shiro;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadLocalToken {
+    private ThreadLocal<String> local = new ThreadLocal<>();
+}


### PR DESCRIPTION
ThreadLocalToken is an **intermediary** between OAuth2Filter & TokenAspect
It stores tokens passed from OAuth2Filter and passed to TokenAspect using **ThreadLocal**