### PR TITLE
Cretae viariables in OAuth2Filter

### DIFF
--- a/src/main/java/com/example/emos/wx/config/shiro/OAuth2Filter.java
+++ b/src/main/java/com/example/emos/wx/config/shiro/OAuth2Filter.java
@@ -2,7 +2,10 @@ package com.example.emos.wx.config.shiro;
 
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.web.filter.authc.AuthenticatingFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletRequest;
@@ -11,6 +14,18 @@ import javax.servlet.ServletResponse;
 @Component
 @Scope("prototype")     // 在springboot中属于多例java类， 非单例类
 public class OAuth2Filter extends AuthenticatingFilter {
+
+    @Autowired
+    private ThreadLocalToken threadLocalToken;
+
+    @Value("${emos.jwt.cache-expire}")
+    private int cacheExpire;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
 
     @Override
     protected AuthenticationToken createToken(ServletRequest servletRequest, ServletResponse servletResponse) throws Exception {


### PR DESCRIPTION
Store token into **threadLocal**
cache-expire will be stored into the cache (Redis)
jwtUtil will **create** and **validate** a token
redisTemplate helps manipulate **Redis**