### PR TITLE
Encapsulate Realm as Object

### DIFF
--- a/src/main/java/com/example/emos/wx/config/shiro/ShiroConfig.java
+++ b/src/main/java/com/example/emos/wx/config/shiro/ShiroConfig.java
@@ -1,7 +1,21 @@
 package com.example.emos.wx.config.shiro;
 
+import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ShiroConfig {
+    /**
+     *  用于封装Realm类对象
+     * */
+    @Bean("securityManager")
+    public SecurityManager securityManager(OAuth2Realm realm) {
+        DefaultWebSecurityManager securityManager = new DefaultWebSecurityManager();
+        securityManager.setRealm(realm);
+        // Token stores in Client but not in Server
+        securityManager.setRememberMeManager(null);
+        return securityManager;
+    }
 }


### PR DESCRIPTION
securityManager is to encapsulate realm as an Object in order that Filter will invoke it
**null** value because **Token** stores in Client rather than Server 