### PR TITLE
Filter as Object and intercept paths requests selectively

### DIFF
--- a/src/main/java/com/example/emos/wx/config/shiro/ShiroConfig.java
+++ b/src/main/java/com/example/emos/wx/config/shiro/ShiroConfig.java
@@ -1,9 +1,16 @@
 package com.example.emos.wx.config.shiro;
 
+import org.apache.commons.collections.map.HashedMap;
 import org.apache.shiro.mgt.SecurityManager;
+import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Filter;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Configuration
 public class ShiroConfig {
@@ -17,5 +24,36 @@ public class ShiroConfig {
         // Token stores in Client but not in Server
         securityManager.setRememberMeManager(null);
         return securityManager;
+    }
+
+    @Bean("shiroFilter")
+    public ShiroFilterFactoryBean shiroFilter(SecurityManager securityManager, OAuth2Filter filter) {
+        ShiroFilterFactoryBean shiroFilter = new ShiroFilterFactoryBean();
+        shiroFilter.setSecurityManager(securityManager);
+
+        // Filter as an Object of HashMap passes to shiroFilter
+        Map<String, Filter> map = new HashMap<>();
+        map.put("oauth2", filter);
+        shiroFilter.setFilters(map);
+
+        // options that intercept requests from paths
+        Map<String, String> filterMap = new LinkedHashMap<>();
+        filterMap.put("/webjars/**", "anon");
+        filterMap.put("/druid/**", "anon");
+        filterMap.put("/app/**", "anon");
+        filterMap.put("/sys/login", "anon");
+        filterMap.put("/swagger/**", "anon");
+        filterMap.put("/v2/api-docs", "anon");
+        filterMap.put("/swagger-ui.html", "anon");
+        filterMap.put("/swagger-resources/**", "anon");
+        filterMap.put("/captcha.jpg", "anon");
+        filterMap.put("/user/register", "anon");
+        filterMap.put("/user/login", "anon");
+        filterMap.put("/test/**", "anon");
+        // all paths requests except above are intercepted by filter
+        filterMap.put("/**", "oauth2");
+        shiroFilter.setFilterChainDefinitionMap(filterMap);
+
+        return shiroFilter;
     }
 }


### PR DESCRIPTION
ShiroFilterFactoryBean plays the role with two goals:
1. Encapsulate **Filter** as an ShiroFilterFactoryBean object passed by Realm Object
2. Selectively filter requests from different paths
